### PR TITLE
Skeleton of the ZMQ link model, with ipm implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ Then start typing commands as follows.
    1. Test the ZMQ link model when variable size payload type gets implemented in framework 2.6
    2. Make PacmanCardWrapper to make instances of the plugin for testing
    3. Write test apps
-   4. Create a set packet format analogous to felix (ask larpix to make a cpp version of their libraries)?
-   5. Scale to many ZMQ links
+   4. Build a passthrough for CCM commands.
+   5. Create a set packet format analogous to felix (ask larpix to make a cpp version of their libraries)?
+   6. Scale to many ZMQ links

--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ To test readout through the framework in a separate terminal launch a readout em
 Then start typing commands as follows.
 
 ## Next development steps:
-   1. Make ZMQLinkModel to handle sockets and data collection 
+   1. Test the ZMQ link model when variable size payload type gets implemented in framework 2.6
    2. Make PacmanCardWrapper to make instances of the plugin for testing
-   3. Implement parser operations
-   4. Write test apps
-   5. Create a set packet format analogous to felix (ask larpix to make a cpp version of their libraries)?
-   6. Scale to many ZMQ links
+   3. Write test apps
+   4. Create a set packet format analogous to felix (ask larpix to make a cpp version of their libraries)?
+   5. Scale to many ZMQ links

--- a/plugins/PacmanCardReader.cpp
+++ b/plugins/PacmanCardReader.cpp
@@ -76,7 +76,7 @@ PacmanCardReader::init(const data_t& args)
       std::vector<std::string> words;
       tokenize(target, delim, words);
 #warning RS FIXME -> Unhandled potential exception.
-      TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating ElinkModel for target queue: " << target; 
+      TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating ZMQLinkModel for target queue: " << target; 
       m_zmqlink = createZMQLinkModel(qi.inst);
       m_zmqlink->init(args, m_queue_capacity);
     }
@@ -99,7 +99,7 @@ PacmanCardReader::do_configure(const data_t& args)
 
   // Configure components
   TLOG(TLVL_WORK_STEPS) << "Configuring ZMQLinkHandler";
-  m_zmqlink->set_id(m_card_id, m_logical_unit, lid, tag);
+  m_zmqlink->set_id(m_card_id, m_logical_unit);
   m_zmqlink->conf(args);
 }
 

--- a/src/CreateZMQLink.hpp
+++ b/src/CreateZMQLink.hpp
@@ -20,14 +20,15 @@ namespace lbrulibs {
 
 createZMQLinkModel(const std::string& target)
 {   
-  if (target.find("output") != std::string::npos) {
+  if (target.find("varsize") != std::string::npos) {
     // Create Model
-    zmqlink_model = std::make_unique<ZMQLinkModel>();
+    auto zmqlink_model = std::make_unique<ZMQLinkModel<readout::types::VariableSizePayloadWrapper>>();
 
     // Setup sink (acquire pointer from QueueRegistry)
     zmqlink_model->set_sink(target);
 
     // Get parser and sink
+    auto& parser = elink_model->get_parser();
     auto& sink = zmqlink_model->get_sink();
 
     // Return with setup model

--- a/src/ZMQLinkConcept.hpp
+++ b/src/ZMQLinkConcept.hpp
@@ -13,6 +13,7 @@
 #include "DefaultParserImpl.hpp"
 
 #include <nlohmann/json.hpp>
+#include "ipm/Subscriber.hpp"
 
 #include <memory>
 #include <sstream>
@@ -24,12 +25,9 @@ namespace lbrulibs {
 class ZMQLinkConcept {
 public:
   ZMQLinkConcept()
-    : m_parser_impl()
-    , m_card_id(0)
+    : m_card_id(0)
     , m_logical_unit(0)
-  { 
-    m_parser = std::make_unique<DefaultParserImpl<>>( m_parser_impl ); //FIX ME - figure out how to make this work properly
-  }
+  {}
   ~ZMQLinkConcept() {}
 
   ZMQLinkConcept(const ZMQLinkConcept&)
@@ -47,36 +45,30 @@ public:
   virtual void start(const nlohmann::json& args) = 0;
   virtual void stop(const nlohmann::json& args) = 0;
 
-  DefaultParserImpl& get_parser() { 
-    return std::ref(m_parser_impl); 
-  }
 
-  void set_ids(int card, int slr, int id, int tag) {
-    m_card_id = card;
-    m_logical_unit = slr;
+    void set_ids(int card, int slr) {
+        m_card_id = card;
+        m_logical_unit = slr;
 
-    std::ostringstream lidstrs;
-    lidstrs << "ZMQLink["
-            << "cid:" << std::to_string(m_card_id) << "|"
-            << "slr:" << std::to_string(m_logical_unit) << "|";
-    m_ZMQLink_str = lidstrs.str();
+        std::ostringstream lidstrs;
+        lidstrs << "ZMQLink["
+                << "cid:" << std::to_string(m_card_id) << "|"
+                << "slr:" << std::to_string(m_logical_unit) << "|";
+        m_ZMQLink_commandLink = lidstrs.str();
 
-    std::ostringstream tidstrs;
-    tidstrs << "ept-" << std::to_string(m_card_id) 
-            << "-" << std::to_string(m_logical_unit);
-    m_ZMQLink_source_tid = tidstrs.str();
-  }
+        std::ostringstream tidstrs;
+        tidstrs << "ept-" << std::to_string(m_card_id) 
+                << "-" << std::to_string(m_logical_unit);
+        m_ZMQLink_sourceLink = tidstrs.str();
+    }
 
 protected:
-  // Block Parser
-  DefaultParserImpl m_parser_impl;
-  std::unique_ptr<DefaultParserImpl<>> m_parser; //FIX ME - figure out how to make this work properly
-
-  int m_card_id;
-  int m_logical_unit;
-  std::string m_ZMQLink_commandLink = "tcp://127.0.0.1:5555";
-  std::string m_ZMQLink_sourceLink = "tcp://127.0.0.1:5556";
-
+    std::shared_ptr<Subscriber> m_input;
+    std::chrono::milliseconds m_queue_timeout;
+    int m_card_id;
+    int m_logical_unit;
+    std::string m_ZMQLink_commandLink = "tcp://127.0.0.1:5555";
+    std::string m_ZMQLink_sourceLink = "tcp://127.0.0.1:5556";
 private:
 
 };

--- a/src/ZMQLinkConcept.hpp
+++ b/src/ZMQLinkConcept.hpp
@@ -84,4 +84,4 @@ private:
 } // namespace lbrulibs
 } // namespace dunedaq
 
-#endif // lbruLIBS_SRC_ZMQLinkCONCEPT_HPP_
+#endif // LBRULIBS_SRC_ZMQLINKCONCEPT_HPP_

--- a/src/ZMQLinkConcept.hpp
+++ b/src/ZMQLinkConcept.hpp
@@ -81,7 +81,7 @@ private:
 
 };
 
-} // namespace flxlibs
+} // namespace lbrulibs
 } // namespace dunedaq
 
-#endif // FLXLIBS_SRC_ZMQLinkCONCEPT_HPP_
+#endif // lbruLIBS_SRC_ZMQLinkCONCEPT_HPP_

--- a/src/ZMQLinkConcept.hpp
+++ b/src/ZMQLinkConcept.hpp
@@ -1,0 +1,87 @@
+/**
+* @file ZMQLinkConcept.hpp ZMQLinkConcept for constructors and
+* forwarding command args. Enforces the implementation to 
+* queue in block_addresses
+*
+* This is part of the DUNE DAQ , copyright 2021.
+* Licensing/copyright details are in the COPYING file that you should have
+* received with this code.
+*/
+#ifndef LBRULIBS_SRC_ZMQLINKCONCEPT_HPP_
+#define LBRULIBS_SRC_ZMQLINKCONCEPT_HPP_
+
+#include "DefaultParserImpl.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace dunedaq {
+namespace lbrulibs {
+
+class ZMQLinkConcept {
+public:
+  ZMQLinkConcept()
+    : m_parser_impl()
+    , m_card_id(0)
+    , m_logical_unit(0)
+  { 
+    m_parser = std::make_unique<DefaultParserImpl<>>( m_parser_impl ); //FIX ME - figure out how to make this work properly
+  }
+  ~ZMQLinkConcept() {}
+
+  ZMQLinkConcept(const ZMQLinkConcept&)
+    = delete; ///< ZMQLinkConcept is not copy-constructible
+  ZMQLinkConcept& operator=(const ZMQLinkConcept&)
+    = delete; ///< ZMQLinkConcept is not copy-assginable
+  ZMQLinkConcept(ZMQLinkConcept&&)
+    = delete; ///< ZMQLinkConcept is not move-constructible
+  ZMQLinkConcept& operator=(ZMQLinkConcept&&)
+    = delete; ///< ZMQLinkConcept is not move-assignable
+
+  virtual void init(const nlohmann::json& args, const size_t queue_capacity) = 0;
+  virtual void set_sink(const std::string& sink_name) = 0;
+  virtual void conf(const nlohmann::json& args) = 0; //add configuration variables later if needed
+  virtual void start(const nlohmann::json& args) = 0;
+  virtual void stop(const nlohmann::json& args) = 0;
+
+  DefaultParserImpl& get_parser() { 
+    return std::ref(m_parser_impl); 
+  }
+
+  void set_ids(int card, int slr, int id, int tag) {
+    m_card_id = card;
+    m_logical_unit = slr;
+
+    std::ostringstream lidstrs;
+    lidstrs << "ZMQLink["
+            << "cid:" << std::to_string(m_card_id) << "|"
+            << "slr:" << std::to_string(m_logical_unit) << "|";
+    m_ZMQLink_str = lidstrs.str();
+
+    std::ostringstream tidstrs;
+    tidstrs << "ept-" << std::to_string(m_card_id) 
+            << "-" << std::to_string(m_logical_unit);
+    m_ZMQLink_source_tid = tidstrs.str();
+  }
+
+protected:
+  // Block Parser
+  DefaultParserImpl m_parser_impl;
+  std::unique_ptr<DefaultParserImpl<>> m_parser; //FIX ME - figure out how to make this work properly
+
+  int m_card_id;
+  int m_logical_unit;
+  std::string m_ZMQLink_commandLink = "tcp://127.0.0.1:5555";
+  std::string m_ZMQLink_sourceLink = "tcp://127.0.0.1:5556";
+
+private:
+
+};
+
+} // namespace flxlibs
+} // namespace dunedaq
+
+#endif // FLXLIBS_SRC_ZMQLinkCONCEPT_HPP_

--- a/src/ZMQLinkModel.hpp
+++ b/src/ZMQLinkModel.hpp
@@ -1,0 +1,171 @@
+/**
+ * @file ZMQLinkModel.hpp FELIX CR's ZMQLink concept wrapper
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef LBRULIBS_SRC_ZMQLINKMODEL_HPP_
+#define LBRULIBS_SRC_ZMQLINKMODEL_HPP_
+
+#include "ZMQLinkConcept.hpp"
+
+#include "readout/ReusableThread.hpp"
+#include "appfwk/DAQSink.hpp"
+#include "logging/Logging.hpp"
+
+#include <nlohmann/json.hpp>
+#include <folly/ProducerConsumerQueue.h>
+
+#include "ipm/Subscriber.hpp"
+
+#include <string>
+#include <mutex>
+#include <atomic>
+#include <memory>
+
+namespace dunedaq::ipm {
+
+template<class TargetPayloadType>
+class ZMQLinkModel : public ZMQLinkConcept {
+public:
+  using sink_t = appfwk::DAQSink<TargetPayloadType>;
+  using inherited = ZMQLinkConcept;
+  using data_t = nlohmann::json;
+
+  /**
+   * @brief ZMQLinkModel Constructor
+   * @param name Instance name for this ZMQLinkModel instance
+   */
+  ZMQLinkModel()
+    : ZMQLinkConcept()
+    , m_run_marker{false}
+    , m_parser_thread(0)
+  { }
+  ~ZMQLinkModel() { }
+
+  void set_sink(const std::string& sink_name) override {
+    if (m_sink_is_set) {
+      TLOG_DEBUG(5) << "ZMQLinkModel sink is already set and initialized!";
+    } else {
+      m_sink_queue = std::make_unique<sink_t>(sink_name);
+      m_sink_is_set = true;
+    }
+  }
+
+  std::unique_ptr<sink_t>& get_sink() {
+    return m_sink_queue;
+  }
+
+  void init(const data_t& /*args*/) {
+    std::shared_ptr<Subscriber> subscriber=makeIPMReceiver("ZmqSubscriber");
+    subscriber->connect_for_receives({ {"connection_string", inherited::m_ZMQLink_sourceLink} });
+  }
+
+  void conf(const data_t& /*args*/) {
+    if (m_configured) {
+      TLOG_DEBUG(5) << "ZMQLinkModel is already configured!";
+    } else {
+      m_parser_thread.set_name(inherited::m_ZMQLink_sourceLink);
+      subscriber->subscribe("");
+      m_configured=true;
+    } 
+  }
+
+  void start(const data_t& /*args*/) {
+    if (!m_run_marker.load()) {
+      set_running(true);
+      m_parser_thread.set_work(&ZMQLinkModel::process_ZMQLink, this);
+      TLOG_DEBUG(5) << "Started ZMQLinkModel...";
+    } else {
+      TLOG_DEBUG(5) << "ZMQLinkModel is already running!";
+    }
+  }
+
+  void stop(const data_t& /*args*/) {
+    if (m_run_marker.load()) {
+      set_running(false);
+      while (!m_parser_thread.get_readiness()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+      TLOG_DEBUG(5) << "Stopped ZMQLinkModel!";
+    } else {
+      TLOG_DEBUG(5) << "ZMQLinkModel is already stopped!";
+    }
+  }
+
+  void set_running(bool should_run) {
+    bool was_running = m_run_marker.exchange(should_run);
+    TLOG_DEBUG(5) << "Active state was toggled from " << was_running << " to " << should_run;
+  }
+
+
+  bool queue_in_message_address(uint64_t addr) { // NOLINT
+    if (m_message_addr_queue->write(addr)) { // ok write
+      return true;
+    } else { // failed write
+      return false;
+    }
+  } 
+
+private:
+  // Types
+  using UniqueMessageAddrQueue = std::unique_ptr<folly::ProducerConsumerQueue<uint64_t>>; // NOLINT
+
+  // Internals
+  std::atomic<bool> m_run_marker;
+  bool m_configured{false};
+
+  // Sink
+  bool m_sink_is_set{false};
+  std::unique_ptr<sink_t> m_sink_queue;
+
+  // mesages to process
+  UniqueMessageAddrQueue m_message_addr_queue;
+
+  // Processor
+  inline static const std::string m_parser_thread_name = "ZMQLinkp";
+  readout::ReusableThread m_parser_thread;
+  void process_ZMQLink() {
+    size_t counter = 0;
+    std::ostringstream oss;
+    while (m_run_marker.load()) {
+        if (m_input->can_receive()) {
+            TLOG_DEBUG(1) << get_name() << ": Creating output vector";
+            std::vector<std::byte> output();
+        try {
+            auto recvd = m_input->receive(inherited::m_queue_timeout);
+            if (recvd.data.size() == 0) {
+                TLOG_DEBUG(1) << "No data received, moving to next loop iteration";
+                continue;
+            }
+
+            memcpy(&output[0], &recvd.data[0]);
+
+            oss << ": Received vector " << counter << " with size " << output.size();
+            ers::info(SubscriberProgressUpdate(ERS_HERE, get_name(), oss.str()));
+            oss.str("");
+        } catch (ReceiveTimeoutExpired const& rte) {
+        TLOG_DEBUG(1) << "ReceiveTimeoutExpired: " << rte.what();
+        continue;
+        }
+
+        TLOG_DEBUG(1) << get_name() << ": Pushing vector into output_queue";
+        try {
+            m_sink_queue->push(std::move(output), inherited::m_queue_timeout);
+        } catch (const appfwk::QueueTimeoutExpired& ex) {
+            ers::warning(ex);
+        }
+
+        TLOG_DEBUG(1) << get_name() << ": End of do_work loop";
+        counter++;
+        } else {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
+  }
+};
+  
+} // namespace dunedaq::ipm
+
+#endif // LBRULIBS_SRC_ZMQLINKMODEL_HPP_

--- a/test/pacmanreadout-commands.json
+++ b/test/pacmanreadout-commands.json
@@ -7,7 +7,7 @@
                         "qinfos": [
                             {
                                 "dir": "output",
-                                "inst": "id_0",
+                                "inst": "varsize_0",
                                 "name": "output0"
                             }
                         ]
@@ -19,7 +19,7 @@
             "queues": [
                 {
                     "capacity": 1000000,
-                    "inst": "id_0",
+                    "inst": "varsize_0",
                     "kind": "FollySPSCQueue"
                 }
             ]


### PR DESCRIPTION
Built a basic version of the ZMQ link model, implementing ZMQ subscriber socket readout based on IPM examples. Included the variable size payload type from the readout repository, can commence testing once it is implemented in framework 2.6.