### PR TITLE
Skeletons for PACMANFrame.hpp and readout types files. Updated goals in README. Simplified packet gen usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 *.exe
 *.out
 *.app
+scripts/readout-test.h5

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ To test readout through the framework in a separate terminal launch a readout em
 Then start typing commands as follows.
 
 ## Next development steps:
-   1. Test the ZMQ link model when variable size payload type gets implemented in framework 2.6
-   2. Make PacmanCardWrapper to make instances of the plugin for testing
-   3. Write test apps
-   4. Build a passthrough for CCM commands.
-   5. Create a set packet format analogous to felix (ask larpix to make a cpp version of their libraries)?
-   6. Scale to many ZMQ links
+   1. Create PACMANFrame.hpp based on unpacking functions from LArPix
+   2. Make a payload type based on the frame
+   3. Create tests to pass the payload through the plugin
+   4. Create a request handler for interfacing with Data Selection
+   5. Build mechanism for writing data to HDF5
+   6. Scale to many ZMQ links and other subdetectors

--- a/plugins/PacmanCardReader.hpp
+++ b/plugins/PacmanCardReader.hpp
@@ -52,7 +52,7 @@ public:
 
 private:
   // Types
-  using module_conf_t = PacmanCardreader::Conf;
+  using module_conf_t = dunedaq::lbrulibs::pacmancardleader::Conf;
   
   // Constants
   static constexpr size_t m_queue_capacity = 1000000;

--- a/scripts/larpix.c
+++ b/scripts/larpix.c
@@ -1,0 +1,147 @@
+#include <stdint.h>
+
+#include "larpix.h"
+
+/* ~~~ Access into message header and message contents ~~~ */
+
+#define WORD_LEN   8  // bytes
+#define HEADER_LEN 16 // bytes
+
+const uint32_t get_msg_bytes(void* msg) {
+    // get total number of bytes in message, including header
+    return HEADER_LEN + WORD_LEN * (*get_msg_words(msg));
+}
+
+#define MSG_TYPE_OFFSET  0 // bytes
+#define MSG_WORDS_OFFSET 6 // bytes
+#define UNIX_TS_OFFSET   1 // bytes
+
+uint8_t* get_msg_type(void* msg) {
+    // get pointer to message type
+    return (uint8_t*)(((uint8_t*)msg) + MSG_TYPE_OFFSET);
+}
+
+uint16_t* get_msg_words(void* msg) {
+    // get pointer to number of message words
+    return (uint16_t*)(((uint8_t*)msg) + MSG_WORDS_OFFSET);
+}
+
+uint32_t* get_msg_unix_ts(void* msg) {
+    // get pointer to message unix timestamp
+    return (uint32_t*)(((uint8_t*)msg) + UNIX_TS_OFFSET);
+}
+
+void* get_msg_word(void* msg, const uint32_t i) {
+    // get pointer to word within message
+    return (void*)(((uint8_t*)msg) + HEADER_LEN + WORD_LEN * i);
+}
+
+
+/* ~~~ Access into message words ~~~ */
+
+#define WORD_TYPE_OFFSET         0 // bytes
+#define IO_CHANNEL_OFFSET        1 // bytes
+#define RECEIPT_TIMESTAMP_OFFSET 4 // bytes
+#define PACKET_OFFSET            8 // bytes
+
+uint8_t* get_word_type(void* word) {
+    // get pointer to word type
+    return (uint8_t*)(((uint8_t*)word) + WORD_TYPE_OFFSET);
+}
+uint8_t* get_word_io_channel(void* word) {
+    // only valid for DATA type words, get pointer to the PACMAN io channel a word arrived on
+    return (uint8_t*)(((uint8_t*)word) + IO_CHANNEL_OFFSET);
+}
+uint32_t* get_word_receipt_timestamp(void* word) {
+    // only valid for DATA type words, get pointer to the timestamp when word was received at the PACMAN
+    return (uint32_t*)(((uint8_t*)word) + RECEIPT_TIMESTAMP_OFFSET);
+}
+uint64_t* get_word_packet(void* word) {
+    // only valid for DATA type words, get pointer to the LArPix word
+    return (uint64_t*)(((uint8_t*)word) + PACKET_OFFSET);
+}
+
+
+/* ~~~ Access into LArPix packets ~~~ */
+
+const uint64_t get_packet_data(uint64_t* packet, const uint8_t bit_offset, const uint64_t bit_mask) {
+    // right-shift packet bits by bit_offset and then grab bits specified by bit_mask
+    return (*packet >> bit_offset) & bit_mask;
+}
+
+#define PACKET_TYPE_OFFSET 0   // bits
+#define PACKET_TYPE_MASK   0x3 // bitmask
+const uint64_t get_packet_type(uint64_t* packet) {
+   // bits [0:1]
+   return get_packet_data(packet, PACKET_TYPE_OFFSET, PACKET_TYPE_MASK);
+}
+
+#define PACKET_CHIPID_OFFSET 8    // bits
+#define PACKET_CHIPID_MASK   0xFF // bitmask
+const uint64_t get_packet_chipid(uint64_t* packet) {
+    // bits [2:9]
+    return get_packet_data(packet, PACKET_CHIPID_OFFSET, PACKET_CHIPID_MASK);
+}
+
+#define PACKET_CHANNELID_OFFSET 10   // bits
+#define PACKET_CHANNELID_MASK   0x3F // bitmask
+const uint64_t get_packet_channelid(uint64_t* packet) {
+    // bits [10:15], only valid for data packets
+    return get_packet_data(packet, PACKET_CHANNELID_OFFSET, PACKET_CHANNELID_MASK);
+}
+
+#define PACKET_TIMESTAMP_OFFSET 16         // bits
+#define PACKET_TIMESTAMP_MASK   0x7FFFFFFF // bitmask
+const uint64_t get_packet_timestamp(uint64_t* packet) {
+    // bits [46:16], only valid for data packets
+    return get_packet_data(packet, PACKET_TIMESTAMP_OFFSET, PACKET_TIMESTAMP_MASK);
+}
+
+#define PACKET_FIRST_PACKET_OFFSET 47  // bits
+#define PACKET_FIRST_PACKET_MASK   0x1 // bitmask
+const uint64_t get_packet_first_packet(uint64_t* packet) {
+    // bits [47], only valid for data packets
+    return get_packet_data(packet, PACKET_FIRST_PACKET_OFFSET, PACKET_FIRST_PACKET_MASK);
+}
+
+#define PACKET_DATAWORD_OFFSET 48   // bits
+#define PACKET_DATAWORD_MASK   0xFF // bitmask
+const uint64_t get_packet_dataword(uint64_t* packet) {
+    // bits [48:55], only valid for data packets
+    return get_packet_data(packet, PACKET_DATAWORD_OFFSET, PACKET_DATAWORD_MASK);
+}
+
+#define PACKET_TRIGGER_TYPE_OFFSET 56  // bits
+#define PACKET_TRIGGER_TYPE_MASK  0x3 // bitmask
+const uint64_t get_packet_trigger_type(uint64_t* packet) {
+    // bits [56:57], only valid for data packets
+    return get_packet_data(packet, PACKET_TRIGGER_TYPE_OFFSET, PACKET_TRIGGER_TYPE_MASK);
+}
+
+#define PACKET_LOCAL_FIFO_STATUS_OFFSET 58  // bits
+#define PACKET_LOCAL_FIFO_STATUS_MASK   0x3 // bitmask
+const uint64_t get_packet_local_fifo_status(uint64_t* packet) {
+    // bits [58:59], only valid for data packets
+    return get_packet_data(packet, PACKET_LOCAL_FIFO_STATUS_OFFSET, PACKET_LOCAL_FIFO_STATUS_MASK);
+}
+
+#define PACKET_SHARED_FIFO_STATUS_OFFSET 60  // bits
+#define PACKET_SHARED_FIFO_STATUS_MASK   0x3 // bitmask
+const uint64_t get_packet_shared_fifo_status(uint64_t* packet) {
+    // bits [60:61], only valid for data packets
+    return get_packet_data(packet, PACKET_SHARED_FIFO_STATUS_OFFSET, PACKET_SHARED_FIFO_STATUS_MASK);
+}
+
+#define PACKET_DOWNSTREAM_MARKER_OFFSET 62  // bits
+#define PACKET_DOWNSTREAM_MARKER_MASK   0x1 // bitmask
+const uint64_t get_packet_downstream_marker(uint64_t* packet) {
+    // bits [62], only valid for data packets
+    return get_packet_data(packet, PACKET_DOWNSTREAM_MARKER_OFFSET, PACKET_DOWNSTREAM_MARKER_MASK);
+}
+
+#define PACKET_PARITY_BIT_MARKER_OFFSET 63  // bits
+#define PACKET_PARITY_BIT_MARKER_MASK   0x1 // bitmask
+const uint64_t get_packet_parity_bit(uint64_t* packet) {
+    // bits [63], only valid for data packets
+    return get_packet_data(packet, PACKET_PARITY_BIT_MARKER_OFFSET, PACKET_PARITY_BIT_MARKER_MASK);
+}

--- a/scripts/larpix.h
+++ b/scripts/larpix.h
@@ -1,0 +1,50 @@
+#include <stdint.h>
+
+#ifndef _LARPIX_H_
+#define _LARPIX_H_
+
+const uint32_t get_msg_bytes(void* msg);
+
+enum msg_type { // message type declarations
+    DATA_MSG = 0x44,
+    REQ_MSG  = 0x3F,
+    REP_MSG  = 0x21
+};
+uint8_t*  get_msg_type(void* msg);
+uint16_t* get_msg_words(void* msg);
+uint32_t* get_msg_unix_ts(void* msg);
+void*     get_msg_word(void* msg, const uint32_t i);
+
+enum word_type { // word type declarations
+    DATA_WORD  = 0x44,
+    TRIG_WORD  = 0x54,
+    SYNC_WORD  = 0x53,
+    PING_WORD  = 0x50,
+    WRITE_WORD = 0x57,
+    READ_WORD  = 0x52,
+    TX_WORD    = 0x44,
+    ERR_WORD   = 0x45
+};
+uint8_t*  get_word_type(void* word);
+uint8_t*  get_word_io_channel(void* word);
+uint32_t* get_word_receipt_timestamp(void* word);
+uint64_t* get_word_packet(void* word);
+
+enum packet_type { // packet type declarations
+    DATA_PACKET         = 0x0,
+    CONFIG_WRITE_PACKET = 0x2,
+    CONFIG_READ_PACKET  = 0x3
+};
+const uint64_t get_packet_type(uint64_t* packet);
+const uint64_t get_packet_chipid(uint64_t* packet);
+const uint64_t get_packet_channelid(uint64_t* packet);
+const uint64_t get_packet_timestamp(uint64_t* packet);
+const uint64_t get_packet_first_packet(uint64_t* packet);
+const uint64_t get_packet_dataword(uint64_t* packet);
+const uint64_t get_packet_trigger_type(uint64_t* packet);
+const uint64_t get_packet_local_fifo_status(uint64_t* packet);
+const uint64_t get_packet_shared_fifo_status(uint64_t* packet);
+const uint64_t get_packet_downstream_marker(uint64_t* packet);
+const uint64_t get_packet_parity_bit(uint64_t* packet);
+
+#endif

--- a/scripts/python-readout.py
+++ b/scripts/python-readout.py
@@ -21,12 +21,15 @@ def readout():
         
         print("Press ENTER to start listening...")
         input()
+        '''
         commander.send(b'')
         print("Signal sent to PACMAN card.")
         commander.recv()
+        '''
 
         messages = 0
         while True:
+            print("Listening on port:",data,"...")
             message = reader.recv()
             print("Message received:", message)
             messages += 1

--- a/src/CreateZMQLink.hpp
+++ b/src/CreateZMQLink.hpp
@@ -26,8 +26,7 @@ createZMQLinkModel(const std::string& target)
     // Setup sink (acquire pointer from QueueRegistry)
     zmqlink_model->set_sink(target);
 
-    // Get parser and sink
-    auto& parser = zmqlink_model->get_parser();
+    // Get sink
     auto& sink = zmqlink_model->get_sink();
 
     // Return with setup model

--- a/src/NDReadoutTypes.hpp
+++ b/src/NDReadoutTypes.hpp
@@ -1,0 +1,67 @@
+/**
+ * @file NDReadoutTypes.hpp Payload type structures for the DUNE Near Detector
+ *
+ * This is part of the DUNE DAQ , copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef LBRULIBS_SRC_NDREADOUTTYPES_HPP_
+#define LBRULIBS_SRC_NDREADOUTTYPES_HPP_
+
+#include "appfwk/DAQSink.hpp"
+#include "appfwk/DAQSource.hpp"
+
+#include "dataformats/FragmentHeader.hpp"
+#include "dataformats/GeoID.hpp"
+#include "PACMANFrame.hpp"
+
+#include <cstdint> // uint_t types
+#include <memory>  // unique_ptr
+
+namespace dunedaq {
+namespace readout {
+namespace types {
+
+/**
+ * @brief PACMAN frame
+ * Size = 816[Bytes] (12*64+1*32+2*8)
+ * */
+const constexpr std::size_t PACMAN_FRAME_SIZE = 816; // FIX ME - check this
+struct PACMAN_MESSAGE_STRUCT
+{
+  // data
+  char data[PACMAN_FRAME_SIZE];
+  // comparable based on first timestamp
+  bool operator<(const PACMAN_MESSAGE_STRUCT& other) const
+  {
+    auto thisptr = reinterpret_cast<const PACMANFrame*>(&data);        // NOLINT
+    auto otherptr = reinterpret_cast<const PACMANFrame*>(&other.data); // NOLINT
+    return thisptr->get_timestamp() < otherptr->get_timestamp() ? true : false;
+  }
+
+  uint64_t get_timestamp() const // NOLINT(build/unsigned)
+  {
+    return reinterpret_cast<const PACMANFrame*>(&data)->get_msg_unix_ts(); // NOLINT
+  }
+
+  void set_timestamp(uint64_t ts) // NOLINT(build/unsigned)
+  {
+    auto frame = reinterpret_cast<PACMANFrame*>(&data); // NOLINT
+    frame->header.msg_unix_timestamp = ts;
+  }
+
+  // FIX ME - figure out what this is and what to do for ND
+  //static const constexpr dataformats::GeoID::SystemType system_type = dataformats::GeoID::SystemType::kTPC;
+  //static const constexpr dataformats::FragmentType fragment_type = dataformats::FragmentType::kTPCData;
+};
+
+typedef dunedaq::appfwk::DAQSink<PACMAN_MESSAGE_STRUCT> PACMANFrameSink;
+typedef std::unique_ptr<PACMANFrameSink> UniquePACMANFrameSink;
+using PACMANFramePtrSink = appfwk::DAQSink<std::unique_ptr<types::PACMAN_MESSAGE_STRUCT>>;
+using UniquePACMANFramePtrSink = std::unique_ptr<PACMANFramePtrSink>;
+
+} // namespace types
+} // namespace readout
+} // namespace dunedaq
+
+#endif // LBRULIBS_SRC_NDREADOUTTYPES_HPP_

--- a/src/PACMANFrame.hpp
+++ b/src/PACMANFrame.hpp
@@ -5,8 +5,8 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
-#ifndef LBRULIBS_SRC_PACMAN_PACMANFRAME_HPP_
-#define LBRULIBS_SRC_PACMAN_PACMANFRAME_HPP_
+#ifndef LBRULIBS_SRC_PACMANFRAME_HPP_
+#define LBRULIBS_SRC_PACMANFRAME_HPP_
 
 #include <bitset>
 #include <iostream>
@@ -201,4 +201,4 @@ private:
 
 } // namespace dunedaq
 
-#endif // LBRULIBS_SRC__PACMAN_PACMANFRAME_HPP_
+#endif // LBRULIBS_SRC_PACMANFRAME_HPP_

--- a/src/PACMANFrame.hpp
+++ b/src/PACMANFrame.hpp
@@ -26,7 +26,8 @@ class PACMANFrame
   
   struct PACMANHeader
   {
-    // To be implemented
+    //FIX ME - To be implemented
+    uint32_t msg_unix_ts;
   };
   
   enum msg_type { // message type declarations

--- a/src/PACMANFrame.hpp
+++ b/src/PACMANFrame.hpp
@@ -17,70 +17,24 @@
 
 namespace dunedaq {
 
-using word_t = uint32_t; // NOLINT(build/unsigned)
-using adc_t = uint16_t;  // NOLINT(build/unsigned)
-
 /**
  * @brief PACMAN header struct
  */
 struct PACMANHeader
 {
-  /* example from WIB
-  word_t sof : 8, version : 5, fiber_no : 3, crate_no : 5, slot_no : 3, reserved_1 : 8;
-  word_t mm : 1, oos : 1, reserved_2 : 14, wib_errors : 16;
-  word_t timestamp_1;
-  word_t timestamp_2 : 16, wib_counter_1 : 15, z : 1;
-  */
-
-};
-
-/* example from WIB of printing header for debugging
-inline std::ostream&
-operator<<(std::ostream& o, PACMANHeader const& h)
-{
-  return o << "SOF:" << unsigned(h.sof) << " version:" << unsigned(h.version) << " fiber:" << unsigned(h.fiber_no)
-           << " slot:" << unsigned(h.slot_no) << " crate:" << unsigned(h.crate_no) << " mm:" << unsigned(h.mm)
-           << " oos:" << unsigned(h.oos) << " wib_errors:" << unsigned(h.wib_errors)
-           << " timestamp: " << h.get_timestamp() << '\n';
-}
-
-/**
- * @brief PACMAN frame
- */
-class PACMANFrame
-{
-  public:
+  const uint32_t msg_bytes;
+  uint8_t msg_type;
+  uint16_t msg_words;
+  uint32_t msg_unix_ts;
+  void msg_word;
 
   enum msg_type { // message type declarations
     DATA_MSG = 0x44,
     REQ_MSG  = 0x3F,
     REP_MSG  = 0x21
   };
-  enum word_type { // word type declarations
-    DATA_WORD  = 0x44,
-    TRIG_WORD  = 0x54,
-    SYNC_WORD  = 0x53,
-    PING_WORD  = 0x50,
-    WRITE_WORD = 0x57,
-    READ_WORD  = 0x52,
-    TX_WORD    = 0x44,
-    ERR_WORD   = 0x45
-  };
-  enum packet_type { // packet type declarations
-    DATA_PACKET         = 0x0,
-    CONFIG_WRITE_PACKET = 0x2,
-    CONFIG_READ_PACKET  = 0x3
-  };
-
   #define WORD_LEN   8  // bytes
   #define HEADER_LEN 16 // bytes
-  #define MSG_TYPE_OFFSET  0 // bytes
-  #define MSG_WORDS_OFFSET 6 // bytes
-  #define UNIX_TS_OFFSET   1 // bytes
-  #define WORD_TYPE_OFFSET         0 // bytes
-  #define IO_CHANNEL_OFFSET        1 // bytes
-  #define RECEIPT_TIMESTAMP_OFFSET 4 // bytes
-  #define PACKET_OFFSET            8 // bytes
 
   /* ~~~ Access into message header and message contents ~~~ */
 
@@ -108,7 +62,40 @@ class PACMANFrame
     // get pointer to word within message
     return (void*)(((uint8_t*)msg) + HEADER_LEN + WORD_LEN * i);
   }
+};
 
+/**
+ * @brief PACMAN frame
+ */
+class PACMANFrame
+{
+  public:
+
+
+  enum word_type { // word type declarations
+    DATA_WORD  = 0x44,
+    TRIG_WORD  = 0x54,
+    SYNC_WORD  = 0x53,
+    PING_WORD  = 0x50,
+    WRITE_WORD = 0x57,
+    READ_WORD  = 0x52,
+    TX_WORD    = 0x44,
+    ERR_WORD   = 0x45
+  };
+  enum packet_type { // packet type declarations
+    DATA_PACKET         = 0x0,
+    CONFIG_WRITE_PACKET = 0x2,
+    CONFIG_READ_PACKET  = 0x3
+  };
+
+
+  #define MSG_TYPE_OFFSET  0 // bytes
+  #define MSG_WORDS_OFFSET 6 // bytes
+  #define UNIX_TS_OFFSET   1 // bytes
+  #define WORD_TYPE_OFFSET         0 // bytes
+  #define IO_CHANNEL_OFFSET        1 // bytes
+  #define RECEIPT_TIMESTAMP_OFFSET 4 // bytes
+  #define PACKET_OFFSET            8 // bytes
 
   /* ~~~ Access into message words ~~~ */
 

--- a/src/PACMANFrame.hpp
+++ b/src/PACMANFrame.hpp
@@ -16,24 +16,50 @@
 namespace dunedaq {
 
 /**
- * @brief PACMAN header struct
+ * @brief PACMAN frame
  */
-struct PACMANHeader
+class PACMANFrame
 {
-  const uint32_t msg_bytes;
-  uint8_t msg_type;
-  uint16_t msg_words;
-  uint32_t msg_unix_ts;
-  void msg_word;
-
+  public:
+  #define WORD_LEN   8  // bytes
+  #define HEADER_LEN 16 // bytes
+  
+  struct PACMANHeader
+  {
+    // To be implemented
+  };
+  
   enum msg_type { // message type declarations
     DATA_MSG = 0x44,
     REQ_MSG  = 0x3F,
     REP_MSG  = 0x21
   };
 
-  #define WORD_LEN   8  // bytes
-  #define HEADER_LEN 16 // bytes
+  enum word_type { // word type declarations
+    DATA_WORD  = 0x44,
+    TRIG_WORD  = 0x54,
+    SYNC_WORD  = 0x53,
+    PING_WORD  = 0x50,
+    WRITE_WORD = 0x57,
+    READ_WORD  = 0x52,
+    TX_WORD    = 0x44,
+    ERR_WORD   = 0x45
+  };
+  enum packet_type { // packet type declarations
+    DATA_PACKET         = 0x0,
+    CONFIG_WRITE_PACKET = 0x2,
+    CONFIG_READ_PACKET  = 0x3
+  };
+
+
+  #define MSG_TYPE_OFFSET  0 // bytes
+  #define MSG_WORDS_OFFSET 6 // bytes
+  #define UNIX_TS_OFFSET   1 // bytes
+  #define WORD_TYPE_OFFSET         0 // bytes
+  #define IO_CHANNEL_OFFSET        1 // bytes
+  #define RECEIPT_TIMESTAMP_OFFSET 4 // bytes
+  #define PACKET_OFFSET            8 // bytes
+
 
   /* ~~~ Access into message header and message contents ~~~ */
 
@@ -61,43 +87,8 @@ struct PACMANHeader
     // get pointer to word within message
     return (void*)(((uint8_t*)msg) + HEADER_LEN + WORD_LEN * i);
   }
-};
 
-/**
- * @brief PACMAN frame
- */
-class PACMANFrame
-{
-  public:
-
-  const PACMANHeader* get_pacman_header() const { return &m_head; }
-  PACMANHeader* get_pacman_header() { return &m_head; }
-
-  enum word_type { // word type declarations
-    DATA_WORD  = 0x44,
-    TRIG_WORD  = 0x54,
-    SYNC_WORD  = 0x53,
-    PING_WORD  = 0x50,
-    WRITE_WORD = 0x57,
-    READ_WORD  = 0x52,
-    TX_WORD    = 0x44,
-    ERR_WORD   = 0x45
-  };
-  enum packet_type { // packet type declarations
-    DATA_PACKET         = 0x0,
-    CONFIG_WRITE_PACKET = 0x2,
-    CONFIG_READ_PACKET  = 0x3
-  };
-
-
-  #define MSG_TYPE_OFFSET  0 // bytes
-  #define MSG_WORDS_OFFSET 6 // bytes
-  #define UNIX_TS_OFFSET   1 // bytes
-  #define WORD_TYPE_OFFSET         0 // bytes
-  #define IO_CHANNEL_OFFSET        1 // bytes
-  #define RECEIPT_TIMESTAMP_OFFSET 4 // bytes
-  #define PACKET_OFFSET            8 // bytes
-
+  
   /* ~~~ Access into message words ~~~ */
 
   uint8_t* get_word_type(void* word) {
@@ -205,7 +196,7 @@ class PACMANFrame
   friend std::ostream& operator<<(std::ostream& o, PACMANFrame const& frame);
 
 private:
-  PACMANHeader m_head;
+  
 };
 
 } // namespace dunedaq

--- a/src/PACMANFrame.hpp
+++ b/src/PACMANFrame.hpp
@@ -1,0 +1,225 @@
+/**
+ * @file PACMANFrame.hpp PACMAN bit fields and accessors
+ *
+ * This is part of the DUNE DAQ , copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef LBRULIBS_SRC__PACMAN_PACMANFRAME_HPP_
+#define LBRULIBS_SRC_PACMAN_PACMANFRAME_HPP_
+
+#include "ers/Issue.hpp"
+
+#include <bitset>
+#include <iostream>
+#include <vector>
+#include <stdint.h>
+
+namespace dunedaq {
+
+using word_t = uint32_t; // NOLINT(build/unsigned)
+using adc_t = uint16_t;  // NOLINT(build/unsigned)
+
+/**
+ * @brief PACMAN header struct
+ */
+struct PACMANHeader
+{
+  /* example from WIB
+  word_t sof : 8, version : 5, fiber_no : 3, crate_no : 5, slot_no : 3, reserved_1 : 8;
+  word_t mm : 1, oos : 1, reserved_2 : 14, wib_errors : 16;
+  word_t timestamp_1;
+  word_t timestamp_2 : 16, wib_counter_1 : 15, z : 1;
+  */
+
+};
+
+/* example from WIB of printing header for debugging
+inline std::ostream&
+operator<<(std::ostream& o, PACMANHeader const& h)
+{
+  return o << "SOF:" << unsigned(h.sof) << " version:" << unsigned(h.version) << " fiber:" << unsigned(h.fiber_no)
+           << " slot:" << unsigned(h.slot_no) << " crate:" << unsigned(h.crate_no) << " mm:" << unsigned(h.mm)
+           << " oos:" << unsigned(h.oos) << " wib_errors:" << unsigned(h.wib_errors)
+           << " timestamp: " << h.get_timestamp() << '\n';
+}
+
+/**
+ * @brief PACMAN frame
+ */
+class PACMANFrame
+{
+  public:
+
+  enum msg_type { // message type declarations
+    DATA_MSG = 0x44,
+    REQ_MSG  = 0x3F,
+    REP_MSG  = 0x21
+  };
+  enum word_type { // word type declarations
+    DATA_WORD  = 0x44,
+    TRIG_WORD  = 0x54,
+    SYNC_WORD  = 0x53,
+    PING_WORD  = 0x50,
+    WRITE_WORD = 0x57,
+    READ_WORD  = 0x52,
+    TX_WORD    = 0x44,
+    ERR_WORD   = 0x45
+  };
+  enum packet_type { // packet type declarations
+    DATA_PACKET         = 0x0,
+    CONFIG_WRITE_PACKET = 0x2,
+    CONFIG_READ_PACKET  = 0x3
+  };
+
+  #define WORD_LEN   8  // bytes
+  #define HEADER_LEN 16 // bytes
+  #define MSG_TYPE_OFFSET  0 // bytes
+  #define MSG_WORDS_OFFSET 6 // bytes
+  #define UNIX_TS_OFFSET   1 // bytes
+  #define WORD_TYPE_OFFSET         0 // bytes
+  #define IO_CHANNEL_OFFSET        1 // bytes
+  #define RECEIPT_TIMESTAMP_OFFSET 4 // bytes
+  #define PACKET_OFFSET            8 // bytes
+
+  /* ~~~ Access into message header and message contents ~~~ */
+
+  const uint32_t get_msg_bytes(void* msg) {
+    // get total number of bytes in message, including header
+    return HEADER_LEN + WORD_LEN * (*get_msg_words(msg));
+  }
+
+  uint8_t* get_msg_type(void* msg) {
+    // get pointer to message type
+    return (uint8_t*)(((uint8_t*)msg) + MSG_TYPE_OFFSET);
+  }
+
+  uint16_t* get_msg_words(void* msg) {
+    // get pointer to number of message words
+    return (uint16_t*)(((uint8_t*)msg) + MSG_WORDS_OFFSET);
+  }
+
+  uint32_t* get_msg_unix_ts(void* msg) {
+    // get pointer to message unix timestamp
+    return (uint32_t*)(((uint8_t*)msg) + UNIX_TS_OFFSET);
+  }
+
+  void* get_msg_word(void* msg, const uint32_t i) {
+    // get pointer to word within message
+    return (void*)(((uint8_t*)msg) + HEADER_LEN + WORD_LEN * i);
+  }
+
+
+  /* ~~~ Access into message words ~~~ */
+
+  uint8_t* get_word_type(void* word) {
+    // get pointer to word type
+    return (uint8_t*)(((uint8_t*)word) + WORD_TYPE_OFFSET);
+  }
+  uint8_t* get_word_io_channel(void* word) {
+    // only valid for DATA type words, get pointer to the PACMAN io channel a word arrived on
+    return (uint8_t*)(((uint8_t*)word) + IO_CHANNEL_OFFSET);
+  }
+  uint32_t* get_word_receipt_timestamp(void* word) {
+    // only valid for DATA type words, get pointer to the timestamp when word was received at the PACMAN
+    return (uint32_t*)(((uint8_t*)word) + RECEIPT_TIMESTAMP_OFFSET);
+  }
+  uint64_t* get_word_packet(void* word) {
+    // only valid for DATA type words, get pointer to the LArPix word
+    return (uint64_t*)(((uint8_t*)word) + PACKET_OFFSET);
+  }
+
+
+  /* ~~~ Access into LArPix packets ~~~ */
+
+  const uint64_t get_packet_data(uint64_t* packet, const uint8_t bit_offset, const uint64_t bit_mask) {
+    // right-shift packet bits by bit_offset and then grab bits specified by bit_mask
+    return (*packet >> bit_offset) & bit_mask;
+  }
+
+  #define PACKET_TYPE_OFFSET 0   // bits
+  #define PACKET_TYPE_MASK   0x3 // bitmask
+  const uint64_t get_packet_type(uint64_t* packet) {
+   // bits [0:1]
+   return get_packet_data(packet, PACKET_TYPE_OFFSET, PACKET_TYPE_MASK);
+  }
+
+  #define PACKET_CHIPID_OFFSET 8    // bits
+  #define PACKET_CHIPID_MASK   0xFF // bitmask
+  const uint64_t get_packet_chipid(uint64_t* packet) {
+    // bits [2:9]
+    return get_packet_data(packet, PACKET_CHIPID_OFFSET, PACKET_CHIPID_MASK);
+  }
+
+  #define PACKET_CHANNELID_OFFSET 10   // bits
+  #define PACKET_CHANNELID_MASK   0x3F // bitmask
+  const uint64_t get_packet_channelid(uint64_t* packet) {
+    // bits [10:15], only valid for data packets
+    return get_packet_data(packet, PACKET_CHANNELID_OFFSET, PACKET_CHANNELID_MASK);
+  }
+
+  #define PACKET_TIMESTAMP_OFFSET 16         // bits
+  #define PACKET_TIMESTAMP_MASK   0x7FFFFFFF // bitmask
+  const uint64_t get_packet_timestamp(uint64_t* packet) {
+    // bits [46:16], only valid for data packets
+    return get_packet_data(packet, PACKET_TIMESTAMP_OFFSET, PACKET_TIMESTAMP_MASK);
+  }
+
+  #define PACKET_FIRST_PACKET_OFFSET 47  // bits
+  #define PACKET_FIRST_PACKET_MASK   0x1 // bitmask
+  const uint64_t get_packet_first_packet(uint64_t* packet) {
+    // bits [47], only valid for data packets
+    return get_packet_data(packet, PACKET_FIRST_PACKET_OFFSET, PACKET_FIRST_PACKET_MASK);
+  }
+
+  #define PACKET_DATAWORD_OFFSET 48   // bits
+  #define PACKET_DATAWORD_MASK   0xFF // bitmask
+  const uint64_t get_packet_dataword(uint64_t* packet) {
+    // bits [48:55], only valid for data packets
+    return get_packet_data(packet, PACKET_DATAWORD_OFFSET, PACKET_DATAWORD_MASK);
+  }
+
+  #define PACKET_TRIGGER_TYPE_OFFSET 56  // bits
+  #define PACKET_TRIGGER_TYPE_MASK  0x3 // bitmask
+  const uint64_t get_packet_trigger_type(uint64_t* packet) {
+    // bits [56:57], only valid for data packets
+    return get_packet_data(packet, PACKET_TRIGGER_TYPE_OFFSET, PACKET_TRIGGER_TYPE_MASK);
+  }
+
+  #define PACKET_LOCAL_FIFO_STATUS_OFFSET 58  // bits
+  #define PACKET_LOCAL_FIFO_STATUS_MASK   0x3 // bitmask
+  const uint64_t get_packet_local_fifo_status(uint64_t* packet) {
+    // bits [58:59], only valid for data packets
+    return get_packet_data(packet, PACKET_LOCAL_FIFO_STATUS_OFFSET, PACKET_LOCAL_FIFO_STATUS_MASK);
+  }
+
+  #define PACKET_SHARED_FIFO_STATUS_OFFSET 60  // bits
+  #define PACKET_SHARED_FIFO_STATUS_MASK   0x3 // bitmask
+  const uint64_t get_packet_shared_fifo_status(uint64_t* packet) {
+    // bits [60:61], only valid for data packets
+    return get_packet_data(packet, PACKET_SHARED_FIFO_STATUS_OFFSET, PACKET_SHARED_FIFO_STATUS_MASK);
+  }
+
+  #define PACKET_DOWNSTREAM_MARKER_OFFSET 62  // bits
+  #define PACKET_DOWNSTREAM_MARKER_MASK   0x1 // bitmask
+  const uint64_t get_packet_downstream_marker(uint64_t* packet) {
+    // bits [62], only valid for data packets
+    return get_packet_data(packet, PACKET_DOWNSTREAM_MARKER_OFFSET, PACKET_DOWNSTREAM_MARKER_MASK);
+  }
+
+  #define PACKET_PARITY_BIT_MARKER_OFFSET 63  // bits
+  #define PACKET_PARITY_BIT_MARKER_MASK   0x1 // bitmask
+  const uint64_t get_packet_parity_bit(uint64_t* packet) {
+    // bits [63], only valid for data packets
+    return get_packet_data(packet, PACKET_PARITY_BIT_MARKER_OFFSET, PACKET_PARITY_BIT_MARKER_MASK);
+  }
+
+  friend std::ostream& operator<<(std::ostream& o, PACMANFrame const& frame);
+
+private:
+  PACMANHeader m_head;
+};
+
+} // namespace dunedaq
+
+#endif // LBRULIBS_SRC__PACMAN_PACMANFRAME_HPP_

--- a/src/PACMANFrame.hpp
+++ b/src/PACMANFrame.hpp
@@ -5,10 +5,8 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
-#ifndef LBRULIBS_SRC__PACMAN_PACMANFRAME_HPP_
+#ifndef LBRULIBS_SRC_PACMAN_PACMANFRAME_HPP_
 #define LBRULIBS_SRC_PACMAN_PACMANFRAME_HPP_
-
-#include "ers/Issue.hpp"
 
 #include <bitset>
 #include <iostream>
@@ -33,6 +31,7 @@ struct PACMANHeader
     REQ_MSG  = 0x3F,
     REP_MSG  = 0x21
   };
+
   #define WORD_LEN   8  // bytes
   #define HEADER_LEN 16 // bytes
 
@@ -71,6 +70,8 @@ class PACMANFrame
 {
   public:
 
+  const PACMANHeader* get_pacman_header() const { return &m_head; }
+  PACMANHeader* get_pacman_header() { return &m_head; }
 
   enum word_type { // word type declarations
     DATA_WORD  = 0x44,

--- a/test/pacman-generator.py
+++ b/test/pacman-generator.py
@@ -82,7 +82,7 @@ def pacman(_echo_server,_cmd_server,_data_server,messages,timestamps):
         print('Press any key to start sending data...')
         input()
         print('Initialising...')
-        time.wait(1)
+        time.sleep(1)
         print('Sending PACMAN messages.')
 
         # Send messages in intervals based on timestamps

--- a/test/pacman-generator.py
+++ b/test/pacman-generator.py
@@ -65,6 +65,7 @@ def pacman(_echo_server,_cmd_server,_data_server,messages,timestamps):
         data_socket.bind(_data_server)
         echo_socket.bind(_echo_server)
         
+        '''
         # Synchronisation with readout
         # Set up a poller, wait for signal from readout to start sending data
         print("Setting up a poller for registering CCM commands...")
@@ -76,7 +77,13 @@ def pacman(_echo_server,_cmd_server,_data_server,messages,timestamps):
             message = cmd_socket.recv()
             print("Signal received.")
             cmd_socket.send(b'')
+        '''
         
+        print('Press any key to start sending data...')
+        input()
+        print('Initialising...')
+        time.wait(1)
+        print('Sending PACMAN messages.')
 
         # Send messages in intervals based on timestamps
         messageCount = 0

--- a/test/pacmanreadout-commands.json
+++ b/test/pacmanreadout-commands.json
@@ -8,7 +8,7 @@
                             {
                                 "dir": "output",
                                 "inst": "varsize_0",
-                                "name": "output0"
+                                "name": "PACMAN0"
                             }
                         ]
                     },


### PR DESCRIPTION
Prepared a skeleton for the PACMANFrame.hpp, with inclusion of all LArPix unpacking functions, still needing to separate out a header struct. Built the core of the NDReadoutTypes file for wrapping frames into payload types. Updated goals in README to reflect current development. Simplified packet generator usage to be "press ENTER to start sending/receiving data" instead of handshaking, for ease of testing with the DAQ framework.