### PR TITLE
Updated the generator to reflect operation of the IPM repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,8 @@ To use the ND-LAr data generator you will need python packages:
 For full functionality, the following additional branches must be locally compiled:
 
 https://github.com/peter-madigan/dataformats/tree/develop
+
 https://github.com/krisfur/readout/tree/kf_newframe
-
-The ZMQ receive socket timeout value in IPM must also be locally hardcoded to a larger value to deal with
-low packet rates. Specifically, line 60 of:
-
-https://github.com/DUNE-DAQ/ipm/blob/develop/plugins/ZmqReceiverImpl.hpp
-
-...should be updated to a timeout of a few seconds (e.g. a value of 10000). A longer term fix is under
-discussion with the IPM developers.
 
 ## ND-LAr: Examples with PACMAN data snapshots
 In one terminal, launch a fake pacman emulation by navigating to the test folder and running:

--- a/src/ZMQLinkConcept.hpp
+++ b/src/ZMQLinkConcept.hpp
@@ -63,7 +63,7 @@ public:
 
 protected:
     std::shared_ptr<ipm::Subscriber> m_subscriber;
-    std::chrono::milliseconds m_queue_timeout;
+    std::chrono::milliseconds m_queue_timeout{1000};
     int m_card_id;
     int m_logical_unit;
     int m_link_tag;

--- a/src/ZMQLinkModel.hpp
+++ b/src/ZMQLinkModel.hpp
@@ -152,7 +152,7 @@ private:
         if (m_subscriber->can_receive()) {
             TLOG_DEBUG(1) << ": Ready to receive data";
         try {
-            auto recvd = m_subscriber->receive(ZMQLinkConcept::m_queue_timeout);
+            auto recvd = m_subscriber->receive(m_queue_timeout);
             if (recvd.data.size() == 0) {
                 TLOG_DEBUG(1) << "No data received, moving to next loop iteration";
                 continue;
@@ -175,7 +175,7 @@ private:
         counter++;
         } else {
             TLOG_DEBUG(1) << "Sleeping";
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+            //std::this_thread::sleep_for(std::chrono::seconds(1));
         }
     }
   }

--- a/test/pacman-generator.py
+++ b/test/pacman-generator.py
@@ -106,6 +106,7 @@ def pacman(_echo_server,_cmd_server,_data_server,word_lists,nRepeats=1):
         
         for n in range(nRepeats):
             for i in word_lists:
+                data_socket.send(b"", zmq.SNDMORE);
                 data_socket.send(pacman_msg_format.format_msg('DATA',i))
                 print(pacman_msg_format.parse_msg(pacman_msg_format.format_msg('DATA',i)))
                 message_count += 1


### PR DESCRIPTION
Changed the pacman generator to send an empty message part before each pacman message since IPM expects a two part message - metadata and data. This solves all readout issues, but is a temporary fix since either PACMAN has to be changed to send in that form, or a new implementation of subscriber has to be written from scratch (might be a 2.10 goal instead).