### PR TITLE
Added 11 new variables

### DIFF
--- a/schema/lbrulibs/pacmancardreaderinfo.jsonnet
+++ b/schema/lbrulibs/pacmancardreaderinfo.jsonnet
@@ -15,8 +15,18 @@ local info = {
                           doc="A string field"),
 
    info: s.record("ZMQLinkInfo", [
-        s.field("num_packets_received",                  self.uint8,     0, doc="Number of packets received"),
-
+             s.field("num_packets_received",                  self.uint8,     0, doc="Number of packets received"),
+	     s.field("last_packet_size",                  self.float8,     0, doc="Message size of last packet"),
+	     s.field("bandwidth",                  self.float8,     0, doc="Bandwidth of last Monitoring Period"),
+	     s.field("time_stamp",                  self.float8,     0, doc="Time Monitoring Period Commences"),
+	     s.field("subscriber_connected",                  self.choice,     0, doc="Data is ready to be received"),
+	     s.field("run_marker",                  self.float8,     0, doc="Run Marker Readout"),
+	     s.field("sink_name",                  self.string,     0, doc="Sink queue name, e.g. PACMAN"),
+	     s.field("subscriber_num_zero_packets",                  self.float8,     0, doc="Times zero data received"),
+	     s.field("sink_is_set",                  self.choice,     0, doc="Has sink succeeded"),
+	     s.field("card_id",                  self.float8,     0, doc="Card ID"),
+	     s.field("link_tag",                  self.float8,     0, doc="Link Tag"),
+	     s.field("source_link_string",                  self.string,     0, doc="Source link string"),
    ], doc="ZMQ Link Information"),
 };
 


### PR DESCRIPTION
Added the following variables, with Will as a reviewer:

- Last Packet Size Received
- Bandwidth
- Time Stamp *from PACMAN message header*
- Subscriber Connected (Data is ready to be received)
- Card ID (ZMQLC)
- Tag (ZMQLC)
- run market (readout)
- Sink queue name
- Times subscriber receives no packets in interval
- Sink is set (sink succeeded)
- source link ID string (ZMQLC)