### PR TITLE
Fixed issue with nanorc commands.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ to generate a config and then:
 
     nanorc mdapp_4proc_pacman_1Hz_pt1second_mode3
 
-to run it. With run commands: boot, init, conf, start 1, resume, (here receive data), stop, scrap, exit
+to run it. With run commands: boot (insance-name), init, conf, start (run number), resume, (here receive data), stop, scrap, exit
 
 ## ND-GAr: TBD
 Configuration steps:

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -29,7 +29,7 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 confgen_arguments=[ "--host-ru", "localhost", "-o", ".", "-n", str(number_of_data_producers), "--frontend-type", "pacman", "-b", "2500000", "-a", "2500000", "-t", "1.0" ]
 # The commands to run in nanorc, as a list
-nanorc_command_list="boot init conf start --resume-wait 1 101 wait ".split() + [str(run_duration)] + " stop --stop-wait 1 wait 2 scrap terminate".split()
+nanorc_command_list="boot integration-test init conf start --resume-wait 1 101 wait ".split() + [str(run_duration)] + " stop --stop-wait 1 wait 2 scrap terminate".split()
 
 # The tests themselves
 def test_nanorc_success(run_nanorc):

--- a/integtest/test_pacman.py
+++ b/integtest/test_pacman.py
@@ -29,7 +29,7 @@ confgen_name="daqconf__multiru_gen"
 # output directory (the test framework handles that)
 confgen_arguments=[ "--host-ru", "localhost", "-o", ".", "-n", str(number_of_data_producers), "--frontend-type", "pacman", "-b", "2500000", "-a", "2500000", "-t", "1.0" ]
 # The commands to run in nanorc, as a list
-nanorc_command_list="boot init conf start --resume-wait 1 101 wait ".split() + [str(run_duration)] + " stop --stop-wait 1 wait 2 scrap terminate".split()
+nanorc_command_list="boot integration-test init conf start --resume-wait 1 101 wait ".split() + [str(run_duration)] + " stop --stop-wait 1 wait 2 scrap terminate".split()
 
 # The tests themselves
 def test_nanorc_success(run_nanorc):


### PR DESCRIPTION
Updated the integration test and the documentation to reflect nanorc now requiring a string after the "boot" command. This closes issue #32 