### PR TITLE
Pacman/fix int test conf

### DIFF
--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -36,13 +36,12 @@ confgen_name="daqconf_multiru_gen"
 detid_ND_LAr = 32 
 number_of_apps = 1 
 hardware_map_contents = integtest_file_gen.generate_hwmap_file( number_of_data_producers, number_of_apps, detid_ND_LAr )
-# generate_hwmap_file, default det_id is HD_TPC. For pacman we use ND_LAr=32
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["daqconf"]["op_env"] = "integtest"
 conf_dict["trigger"]["trigger_rate_hz"]="1.0"
 conf_dict["trigger"]["trigger_window_before_ticks"] = "2500000"
-conf_dict["trigger"]["trigger_window_after_ticks"] = "2500000"
+conf_dict["trigger"]["trigger_window_after_ticks"]  = "2500000"
 
 confgen_arguments={"PACMANSystem": conf_dict}
 
@@ -75,7 +74,7 @@ import zmq
 
 data_socket = 'tcp://127.0.0.1:5556'
 #data_file = '../test/example-pacman-data.h5'
-data_file = '/dune/app/users/jtenavid/Software/DuneDAQ/v3.1.1/Develop_N22-09-07/sourcecode/lbrulibs/test/example-pacman-data.h5'
+data_file = '../test/example-pacman-data.h5'
 
 def hdf5ToPackets(datafile): 
     print("Reading from:",datafile)
@@ -122,7 +121,7 @@ def sender(_data_server,word_lists):
         print('Sending PACMAN data.')
         for i in word_lists:
             data_socket.send_multipart([id,larpixtools.format_msg('DATA',i)])
-            time.sleep(1)
+            time.sleep(0.1)
     except:
         raise
     finally:   

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -38,7 +38,7 @@ number_of_apps = 1
 hardware_map_contents = integtest_file_gen.generate_hwmap_file( number_of_data_producers, number_of_apps, detid_ND_LAr )
 
 conf_dict = config_file_gen.get_default_config_dict()
-conf_dict["daqconf"]["op_env"] = "integtest"
+conf_dict["boot"]["op_env"] = "integtest"
 conf_dict["trigger"]["trigger_rate_hz"]="1.0"
 conf_dict["trigger"]["trigger_window_before_ticks"] = "2500000"
 conf_dict["trigger"]["trigger_window_after_ticks"]  = "2500000"

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -73,7 +73,6 @@ import larpixtools
 import zmq
 
 data_socket = 'tcp://127.0.0.1:5556'
-#data_file = '../test/example-pacman-data.h5'
 data_file = '../test/example-pacman-data.h5'
 
 def hdf5ToPackets(datafile): 

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -1,33 +1,51 @@
 import pytest
 import dfmodules.data_file_checks as data_file_checks
+import dfmodules.integtest_file_gen as integtest_file_gen
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.config_file_gen as config_file_gen
+
 # Values that help determine the running conditions
 number_of_data_producers=1
 run_duration=60  # seconds
+
 # Default values for validation parameters
 expected_number_of_data_files=1
 check_for_logfile_errors=True
 expected_event_count=run_duration
 expected_event_count_tolerance=2
 
-#wib1_frag_hsi_trig_params={"fragment_type_description": "Pacman", "hdf5_groups": "NDLArTPC/Region000",
-#                           "element_name_prefix": "Element", "element_number_offset": 0,
-#                           "expected_fragment_count": number_of_data_producers,
-#                           "min_size_bytes": 80, "max_size_bytes": 1048656}
-
-wib1_frag_hsi_trig_params={"fragment_type_description": "Pacman",
-                           "hdf5_detector_group": "NDLArTPC", "hdf5_region_prefix": "Region",
-                           "element_name_prefix": "Element", "element_number_offset": 0, "expected_fragment_count": number_of_data_producers,
-                           "min_size_bytes": 80, "max_size_bytes": 1048656}
+wib1_frag_hsi_trig_params={"fragment_type_description": "PACMAN",
+                           "fragment_type": "PACMAN",
+                           "hdf5_source_subsystem": "Detector_Readout",
+                           "hdf5_detector_group": "NDLArTPC", 
+                           "hdf5_region_prefix": "Region",
+                           "element_name_prefix": "Element", 
+                           "element_number_offset": 0, 
+                           "expected_fragment_count": number_of_data_producers,
+                           "min_size_bytes": 80, 
+                           "max_size_bytes": 1048656}
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
+
 # The name of the python module for the config generation
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-confgen_arguments=[ "--host-ru", "localhost", "-o", ".", "-n", str(number_of_data_producers), "--frontend-type", "pacman", "-b", "2500000", "-a", "2500000", "-t", "1.0", "--op-env", "integtest" ]
+detid_ND_LAr = 32 
+number_of_apps = 1 
+hardware_map_contents = integtest_file_gen.generate_hwmap_file( number_of_data_producers, number_of_apps, detid_ND_LAr )
+# generate_hwmap_file, default det_id is HD_TPC. For pacman we use ND_LAr=32
+
+conf_dict = config_file_gen.get_default_config_dict()
+conf_dict["daqconf"]["op_env"] = "integtest"
+conf_dict["trigger"]["trigger_rate_hz"]="1.0"
+conf_dict["trigger"]["trigger_window_before_ticks"] = "2500000"
+conf_dict["trigger"]["trigger_window_after_ticks"] = "2500000"
+
+confgen_arguments={"PACMANSystem": conf_dict}
+
 # The commands to run in nanorc, as a list
 nanorc_command_list="integtest-partition boot conf start 101 wait 1 enable_triggers wait ".split() + [str(run_duration)] + "disable_triggers wait 2 stop_run wait 2 scrap terminate".split()
 
@@ -57,7 +75,7 @@ import zmq
 
 data_socket = 'tcp://127.0.0.1:5556'
 #data_file = '../test/example-pacman-data.h5'
-data_file = '/nfs/home/jpanduro/dunedaq-v3.1.0-1/sourcecode/lbrulibs/test/example-pacman-data.h5'
+data_file = '/dune/app/users/jtenavid/Software/DuneDAQ/v3.1.1/Develop_N22-09-07/sourcecode/lbrulibs/test/example-pacman-data.h5'
 
 def hdf5ToPackets(datafile): 
     print("Reading from:",datafile)


### PR DESCRIPTION
New developments in the DAQ software broke the previous configuration of nanorc for this integration test. Consequently, nanorc could not be booted. This flagged the following error:

> Error: Invalid value for 'TOP_CFG': TOP_CFG should either be a directory, a json file, or a config service utility with the form confservice://the_conf_name?1 (where the ?1 at the end is optionnal and represents the version). You provided: '/tmp/pytest-of-jtenavid/pytest-3/json0'

This pull request addresses this issue by updating the configen method to the latest format. For reference, an example of a minimal system quick test can be found [https://github.com/DUNE-DAQ/dfmodules/blob/develop/integtest/minimal_system_quick_test.py](here). The updated configuration for pacman is equivalent to the previous one.

Additional bugs were encountered and fixed by Eric Flumerfelt. These correspond to: 
- https://github.com/DUNE-DAQ/daqconf/pull/177
- https://github.com/DUNE-DAQ/daqconf/commit/de39907809dfbd6eb01b81243777de1477095d9d

With the configuration changes and the two bug fixes above, the configuration of nanorc for pacman is successful and it is possible to run the integration test.

The integration test was failing due to the following error:

>  ----------
> Problem(s) found in logfile /tmp/pytest-of-jtenavid/pytest-38/run0/log_trigger_3334.txt:
> 2022-Sep-08 10:01:53,990 ERROR [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /tmp/root/spack-stage/spack-stage-trigger-N22-09-07-k5km7thts2l6qww5q247cz66dntbgg5s/spack-src/plugins/ModuleLevelTrigger.cpp:281] TC of type 1, timestamp 83132465600034950 overlaps with previous TD readout window: [83132465597534950, 83132465602534950] DAQModule: mlt
> 

This warning goes away when we set a sleeping time between pacman packets of 0.1s. 
