### PR TITLE
Fixes for the test_pacman-raw.py automated integration test

### DIFF
--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -48,6 +48,9 @@ confgen_arguments={"PACMANSystem": conf_dict}
 # The commands to run in nanorc, as a list
 nanorc_command_list="integtest-partition boot conf start 101 wait 1 enable_triggers wait ".split() + [str(run_duration)] + "disable_triggers wait 2 stop_run wait 2 scrap terminate".split()
 
+# Don't require the --frame-file option since we don't need it
+frame_file_required=False
+
 # The tests themselves
 def test_nanorc_success(run_nanorc):
     # Check that nanorc completed correctly

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -4,6 +4,7 @@ import dfmodules.data_file_checks as data_file_checks
 import dfmodules.integtest_file_gen as integtest_file_gen
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.config_file_gen as config_file_gen
+import os
 
 # Values that help determine the running conditions
 number_of_data_producers=1
@@ -74,15 +75,16 @@ def test_data_file(run_nanorc):
         assert data_file_checks.check_event_count(data_file,60,10)
         assert data_file_checks.check_fragment_count(data_file, wib1_frag_hsi_trig_params)
 
+lbrulibs_dir=os.path.realpath(os.path.dirname(__file__) + "/../")
 # Set up the message sender here:
 import time
 import sys
-sys.path.insert(1, '../scripts')
+sys.path.insert(1, f"{lbrulibs_dir}/scripts")
 import larpixtools
 import zmq
 
 data_socket = 'tcp://127.0.0.1:5556'
-data_file = '../test/example-pacman-data.h5'
+data_file = f"{lbrulibs_dir}/test/example-pacman-data.h5"
 
 def hdf5ToPackets(datafile): 
     print("Reading from:",datafile)

--- a/integtest/test_pacman.py
+++ b/integtest/test_pacman.py
@@ -31,6 +31,9 @@ confgen_arguments=[ "--host-ru", "localhost", "-o", ".", "-n", str(number_of_dat
 # The commands to run in nanorc, as a list
 nanorc_command_list="integtest-partition boot conf start 101 wait 1 enable_triggers wait ".split() + [str(run_duration)] + "disable_triggers wait 2 stop_run wait 2 scrap terminate".split()
 
+# Don't require the --frame-file option since we don't need it
+frame_file_required=False
+
 # The tests themselves
 def test_nanorc_success(run_nanorc):
     # Check that nanorc completed correctly

--- a/src/CreateSTREAMLink.hpp
+++ b/src/CreateSTREAMLink.hpp
@@ -17,6 +17,17 @@
 #include <string>
 
 namespace dunedaq {
+
+// 09-Dec-2022, KAB: Added the declaration of the message type string for the 
+// PACMAN message struct, needed for serialization of this struct when sending
+// or receiving it over the network with the IOManager ConnectivityService changes.
+// In this header file, this is done in a way that support its declaration in other
+// header files in this package (because this level of safety is needed).
+#ifndef LBRULIBS_SRC_DEFINE_TYPESTRINGS_
+#define LBRULIBS_SRC_DEFINE_TYPESTRINGS_
+DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::PACMAN_MESSAGE_STRUCT, "PACMAN")
+#endif // LBRULIBS_SRC_DEFINE_TYPESTRINGS_
+
 namespace lbrulibs {
 
 std::unique_ptr<STREAMLinkConcept>

--- a/src/CreateZMQLink.hpp
+++ b/src/CreateZMQLink.hpp
@@ -17,6 +17,17 @@
 #include <string>
 
 namespace dunedaq {
+
+// 09-Dec-2022, KAB: Added the declaration of the message type string for the 
+// PACMAN message struct, needed for serialization of this struct when sending
+// or receiving it over the network with the IOManager ConnectivityService changes.
+// In this header file, this is done in a way that support its declaration in other
+// header files in this package (because this level of safety is needed).
+#ifndef LBRULIBS_SRC_DEFINE_TYPESTRINGS_
+#define LBRULIBS_SRC_DEFINE_TYPESTRINGS_
+DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::PACMAN_MESSAGE_STRUCT, "PACMAN")
+#endif // LBRULIBS_SRC_DEFINE_TYPESTRINGS_
+
 namespace lbrulibs {
 
 std::unique_ptr<ZMQLinkConcept>


### PR DESCRIPTION
I noticed that the `test_pacman-raw.py` automated integration test had stopped working in a recently nightly build. I found that this could be fixed by adding the appropriate MACRO calls in `CreateSTREAMLink` and `CreateZMQLink`.  

This Pull Request has those changes.  

It also has changes to the `test_pacman-raw.py` and `test_pacman.py` files themselves to allow users to skip the specification of a `frames.bin` file on the command line when running those tests. This change has been available for quite some time on the `kbiery/AllowNoFrameFile` branch, and I don't remember why it hasn't been merged already.  But, re-purposed that branch for these changes.

To test this PR, I suggest running the following commands with the develop branch of `lbrulibs`, seeing that they fail in different ways...
```
pytest -s test_pacman-raw.py
pytest -s test_pacman-raw.py  --frame-file $PWD/frames.bin
```

then, update the `lbrulibs` branch to `kbiery/AllowNoFrameFile` and run the following command, which hopefully will succeed:
```
pytest -s test_pacman-raw.py
```