### PR TITLE
Updated PACMAN and MPD message struct TYPESTRINGs

### DIFF
--- a/src/CreateSTREAMLink.hpp
+++ b/src/CreateSTREAMLink.hpp
@@ -26,8 +26,8 @@ namespace dunedaq {
 // header files in this package (because this level of safety is needed).
 #ifndef LBRULIBS_SRC_DEFINE_TYPESTRINGS_
 #define LBRULIBS_SRC_DEFINE_TYPESTRINGS_
-DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::PACMAN_MESSAGE_STRUCT, "PACMAN")
-DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::MPD_MESSAGE_STRUCT, "MPD")
+DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::PACMAN_MESSAGE_STRUCT, "PACMANFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::MPD_MESSAGE_STRUCT, "MPDFrame")
 #endif // LBRULIBS_SRC_DEFINE_TYPESTRINGS_
 
 namespace lbrulibs {

--- a/src/CreateZMQLink.hpp
+++ b/src/CreateZMQLink.hpp
@@ -26,8 +26,8 @@ namespace dunedaq {
 // header files in this package (because this level of safety is needed).
 #ifndef LBRULIBS_SRC_DEFINE_TYPESTRINGS_
 #define LBRULIBS_SRC_DEFINE_TYPESTRINGS_
-DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::PACMAN_MESSAGE_STRUCT, "PACMAN")
-DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::MPD_MESSAGE_STRUCT, "MPD")
+DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::PACMAN_MESSAGE_STRUCT, "PACMANFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::ndreadoutlibs::types::MPD_MESSAGE_STRUCT, "MPDFrame")
 #endif // LBRULIBS_SRC_DEFINE_TYPESTRINGS_
 
 namespace lbrulibs {


### PR DESCRIPTION
... to include Frame in the name.

I believe that these changes are related to ones in `readoutmodules` that were merged a week or so ago to make use of connection data types when constructing plugins.

Before these changes, I would see complaints from the lbrulibs/integtest/test_pacman-raw.py and test_mpd-raw.py tests about the inability to serialize the PACMAN_MESSAGE_STRUCT or the MPD_MESSAGE_STRUCT.

After these changes, those errors went away.  

- test_mpd-raw.py runs fine (with the hsilibs::kbiery/MPDtests branch). 
- However, the DataLinkHandler occasionally crashes in test_pacman-raw.py.  I am not sure if that is related, so I will file a separate Issue.