### PR TITLE
Reverted the change to the trigger rate in test_mpd-raw.py...

### DIFF
--- a/integtest/test_mpd-raw.py
+++ b/integtest/test_mpd-raw.py
@@ -6,7 +6,7 @@ import integrationtest.config_file_gen as config_file_gen
 
 # Values that help determine the running conditions
 number_of_data_producers=1
-rate = 0.5
+rate = 1.0
 sleep_time = 0 
 sent_data = 100
 


### PR DESCRIPTION
I believe that the origin value of 1.0 Hz is the right one to be using.
And, I believe that the errors/warnings that led to the change in trigger rate were caused by a bug in ndreadoutlibs.  I'll file a PR in that repo soon.