### PR TITLE
Converted the two primary integtests that we use in lbrulibs to use D…

### DIFF
--- a/integtest/test_mpd-raw.py
+++ b/integtest/test_mpd-raw.py
@@ -37,7 +37,7 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 detid_NDLAr_PDS = 33 
 number_of_apps = 1 
-hardware_map_contents = integtest_file_gen.generate_hwmap_file( number_of_data_producers, number_of_apps, detid_NDLAr_PDS )
+dro_map_contents = integtest_file_gen.generate_dromap_contents( number_of_data_producers, number_of_apps, detid_NDLAr_PDS, 'eth', 'zmq')
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["boot"]["op_env"] = "integtest"

--- a/integtest/test_mpd-raw.py
+++ b/integtest/test_mpd-raw.py
@@ -37,7 +37,7 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 detid_NDLAr_PDS = 33 
 number_of_apps = 1 
-dro_map_contents = integtest_file_gen.generate_dromap_contents( number_of_data_producers, number_of_apps, detid_NDLAr_PDS, 'eth', 'zmq')
+dro_map_contents = integtest_file_gen.generate_dromap_contents( number_of_data_producers, number_of_apps, detid_NDLAr_PDS, app_type='eth', eth_protocol='zmq')
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["boot"]["op_env"] = "integtest"

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -37,15 +37,10 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 detid_ND_LAr = 32 
 number_of_apps = 1 
-hardware_map_contents = integtest_file_gen.generate_hwmap_file( number_of_data_producers, number_of_apps, detid_ND_LAr )
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_apps, detid_ND_LAr, 'eth', 'zmq')
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["boot"]["op_env"] = "integtest"
-try:
-  urllib.request.urlopen('http://localhost:5000').status
-  conf_dict["boot"]["use_connectivity_service"] = True
-except:
-  conf_dict["boot"]["use_connectivity_service"] = False
 conf_dict["trigger"]["trigger_rate_hz"]="1.0"
 conf_dict["trigger"]["trigger_window_before_ticks"] = "2500000"
 conf_dict["trigger"]["trigger_window_after_ticks"]  = "2500000"

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -37,7 +37,7 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 detid_ND_LAr = 32 
 number_of_apps = 1 
-dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_apps, detid_ND_LAr, 'eth', 'zmq')
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_apps, detid_ND_LAr, app_type='eth', eth_protocol='zmq')
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["boot"]["op_env"] = "integtest"


### PR DESCRIPTION
…etector Readout Maps instead of Hardware Maps.

These changes are related to changes in other repos. The full set of repos is the following:  `daqconf, daq-systemtest, dfmodules, lbrulibs, listrev, `and` integrationtest`.

More information about the changes, and instructions for how to test them, are included in the [daqconf PR (number 295)](https://github.com/DUNE-DAQ/dfmodules/pull/295).