### PR TITLE
Modified integtests to reflect the move of the data_file_checks and d…

### DIFF
--- a/integtest/test_mpd-raw.py
+++ b/integtest/test_mpd-raw.py
@@ -1,6 +1,6 @@
 import pytest
-import dfmodules.data_file_checks as data_file_checks
-import dfmodules.integtest_file_gen as integtest_file_gen
+import integrationtest.data_file_checks as data_file_checks
+import integrationtest.dro_map_gen as dro_map_gen
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.config_file_gen as config_file_gen
 
@@ -37,7 +37,7 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 detid_NDLAr_PDS = 33 
 number_of_apps = 1 
-dro_map_contents = integtest_file_gen.generate_dromap_contents( number_of_data_producers, number_of_apps, detid_NDLAr_PDS, app_type='eth', eth_protocol='zmq')
+dro_map_contents = dro_map_gen.generate_dromap_contents( number_of_data_producers, number_of_apps, detid_NDLAr_PDS, app_type='eth', eth_protocol='zmq')
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["detector"]["op_env"] = "integtest"

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -1,7 +1,7 @@
 import pytest
 import urllib.request
-import dfmodules.data_file_checks as data_file_checks
-import dfmodules.integtest_file_gen as integtest_file_gen
+import integrationtest.data_file_checks as data_file_checks
+import integrationtest.dro_map_gen as dro_map_gen
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.config_file_gen as config_file_gen
 import os
@@ -37,7 +37,7 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 detid_ND_LAr = 32 
 number_of_apps = 1 
-dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_apps, detid_ND_LAr, app_type='eth', eth_protocol='zmq')
+dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers, number_of_apps, detid_ND_LAr, app_type='eth', eth_protocol='zmq')
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["detector"]["op_env"] = "integtest"

--- a/integtest/test_pacman.py
+++ b/integtest/test_pacman.py
@@ -1,5 +1,5 @@
 import pytest
-import dfmodules.data_file_checks as data_file_checks
+import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 # Values that help determine the running conditions
 number_of_data_producers=1


### PR DESCRIPTION
…ro_map_gen files from the dfmodules repo to the integrationtests repo.

These changes will need to be tested and merged in coordination with the changes in the `integrationtests` repo.

Here are instructions for testing these changes during the time period in which the `integrationtest` changes are still on a branch:

```
set up an ND software area based on a recent nightly build
add the integrationtest repo to your software area and install the new code
* git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/move_dfmodules_funcs
* cd integrationtest
* pip install -U .
* cd ..
switch to this branch in lbrulibs
* cd sourcecode/lbrulibs
* git checkout kbiery/move_integtest_funcs
* cd ../../
temporarily modify the PYTHONPATH environmental variable to avoid the use of python modules from the base release dfmodules package
* export PYTHONPATH=`echo $PYTHONPATH | sed 's,dfmodules-NB,trigger-NB,'`
run the integtests...
```
