### PR TITLE
DAQ conf split

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ requests. These can be safely ignored.
 
 To use nanorc instead (preffered for testing) use:
 
-    daqconf_multiru_gen --host-ru localhost -o . --number-of-data-producers 1 --frontend-type pacman --trigger-window-before-ticks 2500000 --trigger-window-after-ticks 2500000 --trigger-rate-hz 1.0 --enable-raw-recording mdapp_4proc_pacman_1Hz_pt1second_mode3
+    nddaqconf_gen --host-ru localhost -o . --number-of-data-producers 1 --frontend-type pacman --trigger-window-before-ticks 2500000 --trigger-window-after-ticks 2500000 --trigger-rate-hz 1.0 --enable-raw-recording mdapp_4proc_pacman_1Hz_pt1second_mode3
 
 to generate a config and then:
 

--- a/integtest/test_mpd-raw.py
+++ b/integtest/test_mpd-raw.py
@@ -32,7 +32,7 @@ mpd_frag_hsi_trig_params={"fragment_type_description": "MPD",
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="nddaqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 detid_NDLAr_PDS = 33 

--- a/integtest/test_mpd-raw.py
+++ b/integtest/test_mpd-raw.py
@@ -32,7 +32,7 @@ mpd_frag_hsi_trig_params={"fragment_type_description": "MPD",
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="nddaqconf_multiru_gen"
+confgen_name="nddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 detid_NDLAr_PDS = 33 

--- a/integtest/test_mpd-raw.py
+++ b/integtest/test_mpd-raw.py
@@ -1,6 +1,6 @@
 import pytest
-import dfmodules.data_file_checks as data_file_checks
-import dfmodules.integtest_file_gen as integtest_file_gen
+import integrationtest.data_file_checks as data_file_checks
+import integrationtest.dro_map_gen as dro_map_gen
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.config_file_gen as config_file_gen
 
@@ -37,7 +37,7 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 detid_NDLAr_PDS = 33 
 number_of_apps = 1 
-dro_map_contents = integtest_file_gen.generate_dromap_contents( number_of_data_producers, number_of_apps, detid_NDLAr_PDS, app_type='eth', eth_protocol='zmq')
+dro_map_contents = dro_map_gen.generate_dromap_contents( number_of_data_producers, number_of_apps, detid_NDLAr_PDS, app_type='eth', eth_protocol='zmq')
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["detector"]["op_env"] = "integtest"

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -32,7 +32,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "PACMAN",
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="nddaqconf_multiru_gen"
+confgen_name="nddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 detid_ND_LAr = 32 

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -32,7 +32,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "PACMAN",
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="nddaqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 detid_ND_LAr = 32 

--- a/integtest/test_pacman-raw.py
+++ b/integtest/test_pacman-raw.py
@@ -1,7 +1,7 @@
 import pytest
 import urllib.request
-import dfmodules.data_file_checks as data_file_checks
-import dfmodules.integtest_file_gen as integtest_file_gen
+import integrationtest.data_file_checks as data_file_checks
+import integrationtest.dro_map_gen as dro_map_gen
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.config_file_gen as config_file_gen
 import os
@@ -37,7 +37,7 @@ confgen_name="daqconf_multiru_gen"
 # output directory (the test framework handles that)
 detid_ND_LAr = 32 
 number_of_apps = 1 
-dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_apps, detid_ND_LAr, app_type='eth', eth_protocol='zmq')
+dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers, number_of_apps, detid_ND_LAr, app_type='eth', eth_protocol='zmq')
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["detector"]["op_env"] = "integtest"

--- a/integtest/test_pacman.py
+++ b/integtest/test_pacman.py
@@ -24,7 +24,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "Pacman",
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="nddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 confgen_arguments=[ "--host-ru", "localhost", "-o", ".", "-n", str(number_of_data_producers), "--frontend-type", "pacman", "-b", "2500000", "-a", "2500000", "-t", "1.0" ]

--- a/integtest/test_pacman.py
+++ b/integtest/test_pacman.py
@@ -1,5 +1,5 @@
 import pytest
-import dfmodules.data_file_checks as data_file_checks
+import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 # Values that help determine the running conditions
 number_of_data_producers=1


### PR DESCRIPTION
This pull request addresses the need to have a daqconf for fd and nd separately. This pull request is associated to a number of pull requests: 
- daqconf: https://github.com/DUNE-DAQ/daqconf/pull/386
- nddaqconf: https://github.com/DUNE-DAQ/nddaqconf/pull/3
- fddaqconf: https://github.com/DUNE-DAQ/fddaqconf/pull/1
- lbrulibs: https://github.com/DUNE-DAQ/lbrulibs/pull/62
- daq-systemtest: https://github.com/DUNE-DAQ/daq-systemtest/pull/64
- dfmodules: https://github.com/DUNE-DAQ/dfmodules/pull/313
- ndreadoutmodules: https://github.com/DUNE-DAQ/ndreadoutmodules/pull/5

You can find the associated issue in https://github.com/DUNE-DAQ/daq-deliverables/issues/119
and the deliverable documentation https://github.com/DUNE-DAQ/daq-deliverables/blob/feature/fddaq_v4.2.0_dev/docs/fddaq-v4.2.0/daqconfSplitForNDFD.md